### PR TITLE
[feat] : 멘티의 멘토 채팅방 CRUD 중 CRD 구현 (#33)

### DIFF
--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -29,9 +29,7 @@ public class ApiV1MenteeChatRoomController {
 
     @GetMapping()
     public RsData<Page<MentorChatRoomResponse>> getMentorChatRooms(
-            @PageableDefault(size = 10, page = 0)Pageable pageable,
-            @RequestParam(value = "category", defaultValue = "") String category,
-            @RequestParam(value = "sub_category", defaultValue = "") String subCategory,
+            @PageableDefault(size = 10, page = 0) Pageable pageable,
             User user // 컴파일 에러 방지용
     ){
         // TODO 로그인한 회원의 정보를 가져와야함

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -1,0 +1,51 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
+import com.moci_3d_backend.domain.user.entity.User;
+import com.moci_3d_backend.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/chat/mentee/room")
+@RequiredArgsConstructor
+public class ApiV1MenteeChatRoomController {
+    private final MentorChatRoomService mentorChatRoomService;
+
+    @PostMapping()
+    public RsData<Void> createMentorChatRoom(
+            @RequestParam(value = "category", defaultValue = "") String category,
+            @RequestParam(value = "sub_category", defaultValue = "") String subCategory,
+            User user // 컴파일 에러 방지용
+    ) {
+        // TODO 로그인한 회원의 정보를 가져와야함
+        mentorChatRoomService.createMentorChatRoom(category, subCategory, user);
+        return RsData.of(201, "success to create chat room");
+    }
+
+    @GetMapping()
+    public RsData<Page<MentorChatRoomResponse>> getMentorChatRooms(
+            @PageableDefault(size = 10, page = 0)Pageable pageable,
+            @RequestParam(value = "category", defaultValue = "") String category,
+            @RequestParam(value = "sub_category", defaultValue = "") String subCategory,
+            User user // 컴파일 에러 방지용
+    ){
+        // TODO 로그인한 회원의 정보를 가져와야함
+        Page<MentorChatRoomResponse> mentorChatRoomResponsePage = mentorChatRoomService.getMentorChatRooms(user, pageable);
+        return RsData.of(200, "success to get chat rooms", mentorChatRoomResponsePage);
+    }
+
+    @DeleteMapping("{room_id}")
+    public RsData<Void> deleteMentorChatRoom(
+            @PathVariable("room_id") Long roomId,
+            User user // 컴파일 에러 방지용
+    ){
+        // TODO 로그인한 회원의 정보를 가져와야함
+        mentorChatRoomService.deleteMentorChatRoom(roomId, user);
+        return RsData.of(200, "success to delete chat room");
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
@@ -1,0 +1,15 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import lombok.Getter;
+
+@Getter
+public class MentorChatRoomResponse {
+    private Long id;
+//    private String question; // Chat Message 구현 후 추가
+
+    public MentorChatRoomResponse(MentorChatRoom entity){
+        this.id = entity.getId();
+
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
@@ -52,7 +52,7 @@ public class MentorChatRoom {
 
     private LocalDateTime menteeLastAt;
 
-    @Setter()
+    @Setter
     private boolean deleted;
 
     @OneToMany(mappedBy = "room")

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
@@ -1,11 +1,15 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity;
 
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorChatMessage;
+import com.moci_3d_backend.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,30 +17,64 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class MentorChatRoom {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(name="category",length = 255)
     private String category;
+
     @Column(name="sub_category" ,length = 255)
     private String subCategory;
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "mentor_id")
-//    private User mentor;
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "mentee_id")
-//    private User mentee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id", nullable = true)
+    private User mentor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentee_id")
+    private User mentee;
+
     private boolean status;
+
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
     private LocalDateTime matchedAt;
+
     private LocalDateTime lastMessageAt;
+
     private LocalDateTime mentorLastAt;
+
     private LocalDateTime menteeLastAt;
+
+    @Setter()
+    private boolean deleted;
 
     @OneToMany(mappedBy = "room")
     List<MentorChatMessage> mentorChatMessageList;
 
+
+    public MentorChatRoom(String category, String subCategory, User mentee){
+        this.category = category;
+        this.subCategory = subCategory;
+        this.mentee = mentee;
+        this.status = true;
+        this.menteeLastAt = LocalDateTime.now();
+        this.deleted = false;
+    }
+
+    public void joinMentor(User mentor){
+        this.mentor = mentor;
+        this.matchedAt = LocalDateTime.now();
+        this.mentorLastAt = LocalDateTime.now();
+    }
+
+    public void updateLastMessageAt(){
+        this.lastMessageAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepository.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepository.java
@@ -1,0 +1,15 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.repository;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import com.moci_3d_backend.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MentorChatRoomRepository extends JpaRepository<MentorChatRoom, Long> {
+    Page<MentorChatRoom> findByMenteeAndDeletedFalse(User mentee, Pageable pageable);
+
+    Optional<MentorChatRoom> findByIdAndDeletedFalse(Long roomId);
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomDtoService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomDtoService.java
@@ -1,0 +1,25 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MentorChatRoomDtoService {
+
+    public MentorChatRoomResponse toMentorChatRoomResponse(MentorChatRoom entity){
+        return new MentorChatRoomResponse(entity);
+    }
+
+    public Page<MentorChatRoomResponse> toMentorChatRoomResponsePage(Page<MentorChatRoom> page){
+        return new PageImpl<>(
+                page.stream().map(this::toMentorChatRoomResponse).toList(),
+                page.getPageable(),
+                page.getTotalElements()
+        );
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
@@ -28,7 +28,7 @@ public class MentorChatRoomService {
         return mentorChatRoomDtoService.toMentorChatRoomResponsePage(mentorChatRoomPage);
     }
 
-    public boolean deleteMentorChatRoom(Long roomId, User user){
+    public void deleteMentorChatRoom(Long roomId, User user){
         MentorChatRoom mentorChatRoom = mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
                 () -> new NoSuchElementException("No chat room found with id: " + roomId)
         );
@@ -36,6 +36,5 @@ public class MentorChatRoomService {
             throw new IllegalArgumentException("The user is not a mentee of the chat room");
         }
         mentorChatRoom.setDeleted(true);
-        return true;
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
@@ -1,0 +1,41 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.repository.MentorChatRoomRepository;
+import com.moci_3d_backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class MentorChatRoomService {
+
+    private final MentorChatRoomRepository mentorChatRoomRepository;
+    private final MentorChatRoomDtoService mentorChatRoomDtoService;
+
+    public void createMentorChatRoom(String category, String subCategory, User mentee){
+        MentorChatRoom mentorChatRoom = new MentorChatRoom(category, subCategory, mentee);
+        mentorChatRoomRepository.save(mentorChatRoom);
+    }
+
+    public Page<MentorChatRoomResponse> getMentorChatRooms(User user, Pageable pageable){
+        Page<MentorChatRoom> mentorChatRoomPage = mentorChatRoomRepository.findByMenteeAndDeletedFalse(user, pageable);
+        return mentorChatRoomDtoService.toMentorChatRoomResponsePage(mentorChatRoomPage);
+    }
+
+    public boolean deleteMentorChatRoom(Long roomId, User user){
+        MentorChatRoom mentorChatRoom = mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
+                () -> new NoSuchElementException("No chat room found with id: " + roomId)
+        );
+        if (!mentorChatRoom.getMentee().equals(user)){
+            throw new IllegalArgumentException("The user is not a mentee of the chat room");
+        }
+        mentorChatRoom.setDeleted(true);
+        return true;
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>
아직은 완전히 기능이 구현된 상태는 아니고 User의 인증 기능이 필요합니다.
멘티가 채팅방을 만들거나 조회하는 기능을 구현했습니다.
채팅방의 소프트 삭제 기능을 구현했습니다.
User 엔티티가 구현되었기 때문에 연결했습니다.


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #33 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [✅] PR 제목 규칙 잘 지켰는가?
- [✅] 추가/수정사항을 설명하였는가?
- [✅] 이슈넘버를 적었는가?
- [✅] Approve 하기 전 확인 사항 체크했는가?
