### PR TITLE
[feat] 멘토채팅방 구현#59

### DIFF
--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/entity/MentorChatMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/entity/MentorChatMessage.java
@@ -6,10 +6,12 @@ import com.moci_3d_backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class MentorChatMessage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -5,6 +5,8 @@ import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomR
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MenteeChatRoomService;
 import com.moci_3d_backend.domain.user.entity.User;
 import com.moci_3d_backend.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -15,10 +17,12 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/chat/mentee/room")
 @RequiredArgsConstructor
+@Tag(name="멘티의 채팅방", description = "멘티의 채팅방 관련 API")
 public class ApiV1MenteeChatRoomController {
     private final MenteeChatRoomService menteeChatRoomService;
 
     @PostMapping()
+    @Operation(summary = "[멘티] 채팅방 생성", description = "멘티가 채팅방을 생성합니다.")
     public RsData<Void> createMentorChatRoom(
             @RequestBody CreateMentorChatRoom createMentorChatRoom,
             User user // 컴파일 에러 방지용
@@ -29,7 +33,8 @@ public class ApiV1MenteeChatRoomController {
     }
 
     @GetMapping()
-    public RsData<List<MentorChatRoomResponse>> getMentorChatRooms(
+    @Operation(summary = "[멘티] 채팅방을 조회합니다.", description = "멘티가 참여한 채팅방을 조회합니다.")
+    public RsData<List<MentorChatRoomResponse>> getMenteeChatRooms(
             @PageableDefault(size = 10, page = 0) Pageable pageable,
             User user // 컴파일 에러 방지용
     ){
@@ -39,7 +44,8 @@ public class ApiV1MenteeChatRoomController {
     }
 
     @DeleteMapping("{room_id}")
-    public RsData<Void> deleteMentorChatRoom(
+    @Operation(summary = "[멘티] 채팅방을 나갑니다.", description = "멘티가 참여한 채팅방을 나갑니다.")
+    public RsData<Void> deleteMenteeChatRoom(
             @PathVariable("room_id") Long roomId,
             User user // 컴파일 에러 방지용
     ){

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -1,39 +1,40 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
 
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.CreateMentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
-import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MenteeChatRoomService;
 import com.moci_3d_backend.domain.user.entity.User;
 import com.moci_3d_backend.global.rsData.RsData;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/chat/mentee/room")
 @RequiredArgsConstructor
 public class ApiV1MenteeChatRoomController {
-    private final MentorChatRoomService mentorChatRoomService;
+    private final MenteeChatRoomService menteeChatRoomService;
 
     @PostMapping()
     public RsData<Void> createMentorChatRoom(
-            @RequestParam(value = "category", defaultValue = "") String category,
-            @RequestParam(value = "sub_category", defaultValue = "") String subCategory,
+            @RequestBody CreateMentorChatRoom createMentorChatRoom,
             User user // 컴파일 에러 방지용
     ) {
         // TODO 로그인한 회원의 정보를 가져와야함
-        mentorChatRoomService.createMentorChatRoom(category, subCategory, user);
+        menteeChatRoomService.createMenteeChatRoom(createMentorChatRoom, user);
         return RsData.of(201, "success to create chat room");
     }
 
     @GetMapping()
-    public RsData<Page<MentorChatRoomResponse>> getMentorChatRooms(
+    public RsData<List<MentorChatRoomResponse>> getMentorChatRooms(
             @PageableDefault(size = 10, page = 0) Pageable pageable,
             User user // 컴파일 에러 방지용
     ){
         // TODO 로그인한 회원의 정보를 가져와야함
-        Page<MentorChatRoomResponse> mentorChatRoomResponsePage = mentorChatRoomService.getMentorChatRooms(user, pageable);
+        List<MentorChatRoomResponse> mentorChatRoomResponsePage = menteeChatRoomService.getMenteeChatRooms(user);
         return RsData.of(200, "success to get chat rooms", mentorChatRoomResponsePage);
     }
 
@@ -43,7 +44,7 @@ public class ApiV1MenteeChatRoomController {
             User user // 컴파일 에러 방지용
     ){
         // TODO 로그인한 회원의 정보를 가져와야함
-        mentorChatRoomService.deleteMentorChatRoom(roomId, user);
+        menteeChatRoomService.deleteMenteeChatRoom(roomId, user);
         return RsData.of(200, "success to delete chat room");
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -5,6 +5,8 @@ import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorCha
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
 import com.moci_3d_backend.domain.user.entity.User;
 import com.moci_3d_backend.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -14,11 +16,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/mentor/chatroom")
 @RequiredArgsConstructor
+@Tag(name="멘토의 채팅방", description = "멘토의 채팅방 관련 API")
 public class ApiV1MentorChatRoomController {
     private final MentorChatRoomService mentorChatRoomService;
 
     @PostMapping("/join/{roomId}")
     @PreAuthorize("hasRole('MENTOR')")
+    @Operation(summary = "[멘토] 채팅방 입장", description = "멘토가 채팅방에 입장합니다.")
     public RsData<Void> joinMentorChatRoom(
             @PathVariable(value = "roomId") Long roomId,
             User user // 컴파일 에러 방지용
@@ -30,6 +34,7 @@ public class ApiV1MentorChatRoomController {
 
     @GetMapping("/my-mentees")
     @PreAuthorize("hasRole('MENTOR')")
+    @Operation(summary = "[멘토] 입장했던 채팅방 조회", description = "멘토가 입장했던 채팅방을 조회합니다.")
     public RsData<List<MentorChatRoomResponse>> getMyMenteeChatRooms(
             User user // 컴파일 에러 방지용
     ){
@@ -40,6 +45,7 @@ public class ApiV1MentorChatRoomController {
 
     @GetMapping("/non-mentor-list")
     @PreAuthorize("hasRole('MENTOR')")
+    @Operation(summary = "[멘토] 입장하지 않은 채팅방을 조회합니다.", description = "멘토가 입장하지 않은 채팅방을 조회합니다.")
     public RsData<List<DetailMentorChatRoom>> getMentorChatRooms(){
         List<DetailMentorChatRoom> chatRooms = mentorChatRoomService.getDetailMentorChatRooms();
         return RsData.of(200, "success to load chat rooms", chatRooms);

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -19,12 +19,13 @@ public class ApiV1MentorChatRoomController {
 
     @PostMapping("/join/{roomId}")
     @PreAuthorize("hasRole('MENTOR')")
-    public void joinMentorChatRoom(
+    public RsData<Void> joinMentorChatRoom(
             @PathVariable(value = "roomId") Long roomId,
             User user // 컴파일 에러 방지용
     ){
         // TODO 로그인한 회원의 정보를 가져와야함
         mentorChatRoomService.joinMentorChatRoom(roomId, user);
+        return RsData.of(200, "success to join mentor chat room");
     }
 
     @GetMapping("/my-mentees")
@@ -32,14 +33,15 @@ public class ApiV1MentorChatRoomController {
     public RsData<List<MentorChatRoomResponse>> getMyMenteeChatRooms(
             User user // 컴파일 에러 방지용
     ){
-        var mentees = mentorChatRoomService.getMentorChatRooms(user);
+        // TODO 로그인한 회원의 정보를 가져와야함
+        List<MentorChatRoomResponse> mentees = mentorChatRoomService.getMentorChatRooms(user);
         return RsData.of(200, "success to load my mentee chat rooms", mentees);
     }
 
-    @GetMapping("/list")
+    @GetMapping("/non-mentor-list")
     @PreAuthorize("hasRole('MENTOR')")
     public RsData<List<DetailMentorChatRoom>> getMentorChatRooms(){
-        var chatRooms = mentorChatRoomService.getDetailMentorChatRooms();
+        List<DetailMentorChatRoom> chatRooms = mentorChatRoomService.getDetailMentorChatRooms();
         return RsData.of(200, "success to load chat rooms", chatRooms);
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -1,0 +1,45 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorChatRoom;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
+import com.moci_3d_backend.domain.user.entity.User;
+import com.moci_3d_backend.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/mentor/chatroom")
+@RequiredArgsConstructor
+public class ApiV1MentorChatRoomController {
+    private final MentorChatRoomService mentorChatRoomService;
+
+    @PostMapping("/join/{roomId}")
+    @PreAuthorize("hasRole('MENTOR')")
+    public void joinMentorChatRoom(
+            @PathVariable(value = "roomId") Long roomId,
+            User user // 컴파일 에러 방지용
+    ){
+        // TODO 로그인한 회원의 정보를 가져와야함
+        mentorChatRoomService.joinMentorChatRoom(roomId, user);
+    }
+
+    @GetMapping("/my-mentees")
+    @PreAuthorize("hasRole('MENTOR')")
+    public RsData<List<MentorChatRoomResponse>> getMyMenteeChatRooms(
+            User user // 컴파일 에러 방지용
+    ){
+        var mentees = mentorChatRoomService.getMentorChatRooms(user);
+        return RsData.of(200, "success to load my mentee chat rooms", mentees);
+    }
+
+    @GetMapping("/list")
+    @PreAuthorize("hasRole('MENTOR')")
+    public RsData<List<DetailMentorChatRoom>> getMentorChatRooms(){
+        var chatRooms = mentorChatRoomService.getDetailMentorChatRooms();
+        return RsData.of(200, "success to load chat rooms", chatRooms);
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/CreateMentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/CreateMentorChatRoom.java
@@ -1,0 +1,9 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateMentorChatRoom {
+    private String category;
+    private String title;
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/DetailMentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/DetailMentorChatRoom.java
@@ -1,0 +1,19 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import lombok.Getter;
+
+@Getter
+public class DetailMentorChatRoom {
+    private Long id;
+    private String title;
+    private String category;
+    private Integer digital_level;
+
+    public DetailMentorChatRoom(MentorChatRoom mentorChatRoom){
+        this.id = mentorChatRoom.getId();
+        this.title = mentorChatRoom.getTitle();
+        this.category = mentorChatRoom.getCategory();
+        this.digital_level = mentorChatRoom.getMentee().getDigitalLevel();
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 public class MentorChatRoomResponse {
     private Long id;
-//    private String question; // Chat Message 구현 후 추가
+    private String title; // Chat Message 구현 후 추가
 
     public MentorChatRoomResponse(MentorChatRoom entity){
         this.id = entity.getId();
-
+        this.title = entity.getTitle();
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
@@ -1,6 +1,7 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity;
 
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorChatMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.CreateMentorChatRoom;
 import com.moci_3d_backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -24,10 +25,13 @@ public class MentorChatRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name="title", length=255)
+    private String title;
+
     @Column(name="category",length = 255)
     private String category;
 
-    @Column(name="sub_category" ,length = 255)
+    @Column(name="sub_category" ,length = 255, nullable = true)
     private String subCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -59,11 +63,19 @@ public class MentorChatRoom {
     List<MentorChatMessage> mentorChatMessageList;
 
 
-    public MentorChatRoom(String category, String subCategory, User mentee){
+    public MentorChatRoom(String category,  User mentee){
         this.category = category;
-        this.subCategory = subCategory;
         this.mentee = mentee;
         this.status = true;
+        this.menteeLastAt = LocalDateTime.now();
+        this.deleted = false;
+    }
+
+    public MentorChatRoom(CreateMentorChatRoom createMentorChatRoom, User mentee){
+        this.category = createMentorChatRoom.getCategory();
+        this.title = createMentorChatRoom.getTitle();
+        this.status = true;
+        this.mentee = mentee;
         this.menteeLastAt = LocalDateTime.now();
         this.deleted = false;
     }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepository.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MentorChatRoomRepository extends JpaRepository<MentorChatRoom, Long> {
-    Page<MentorChatRoom> findByMenteeAndDeletedFalse(User mentee, Pageable pageable);
+    List<MentorChatRoom> findByMenteeAndDeletedFalse(User mentee);
+    List<MentorChatRoom> findByMentorNullAndDeletedFalse();
+    List<MentorChatRoom> findByMentorAndDeletedFalse(User mentor);
 
     Optional<MentorChatRoom> findByIdAndDeletedFalse(Long roomId);
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MenteeChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MenteeChatRoomService.java
@@ -1,0 +1,48 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.CreateMentorChatRoom;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.repository.MentorChatRoomRepository;
+import com.moci_3d_backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class MenteeChatRoomService {
+
+    private final MentorChatRoomRepository mentorChatRoomRepository;
+    private final MentorChatRoomDtoService mentorChatRoomDtoService;
+
+    @Transactional
+    public void createMenteeChatRoom(CreateMentorChatRoom createMentorChatRoom, User mentee){
+        MentorChatRoom mentorChatRoom = new MentorChatRoom(createMentorChatRoom, mentee);
+        mentorChatRoomRepository.save(mentorChatRoom);
+    }
+
+    public List<MentorChatRoomResponse> getMenteeChatRooms(User mentee){
+        List<MentorChatRoom> mentorChatRoomPage = mentorChatRoomRepository.findByMenteeAndDeletedFalse(mentee);
+        return mentorChatRoomDtoService.toMentorChatRoomResponseList(mentorChatRoomPage);
+    }
+
+    @Transactional
+    public void deleteMenteeChatRoom(Long roomId, User mentee){
+        MentorChatRoom mentorChatRoom = getMenteeChatRoom(roomId, mentee);
+        mentorChatRoom.setDeleted(true);
+    }
+
+    public MentorChatRoom getMenteeChatRoom(Long roomId, User mentee){
+        MentorChatRoom mentorChatRoom =  mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
+                () -> new NoSuchElementException("No chat room found with id: " + roomId)
+        );
+        if (!mentorChatRoom.getMentee().equals(mentee)){
+            throw new IllegalArgumentException("The user is not a mentee of the chat room");
+        }
+        return mentorChatRoom;
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomDtoService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomDtoService.java
@@ -1,11 +1,12 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service;
 
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,11 +16,20 @@ public class MentorChatRoomDtoService {
         return new MentorChatRoomResponse(entity);
     }
 
-    public Page<MentorChatRoomResponse> toMentorChatRoomResponsePage(Page<MentorChatRoom> page){
-        return new PageImpl<>(
-                page.stream().map(this::toMentorChatRoomResponse).toList(),
-                page.getPageable(),
-                page.getTotalElements()
-        );
+    public DetailMentorChatRoom toDetailMentorChatRoom(MentorChatRoom entity){
+        return new DetailMentorChatRoom(entity);
     }
+
+    public List<MentorChatRoomResponse> toMentorChatRoomResponseList(List<MentorChatRoom> mentorChatRoomList){
+        return mentorChatRoomList.stream()
+                .map(this::toMentorChatRoomResponse)
+                .toList();
+    }
+
+    public List<DetailMentorChatRoom> toDetailMentorChatRoomList(List<MentorChatRoom> mentorChatRoomList){
+        return mentorChatRoomList.stream()
+                .map(this::toDetailMentorChatRoom)
+                .toList();
+    }
+
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
@@ -1,15 +1,15 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service;
 
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.repository.MentorChatRoomRepository;
 import com.moci_3d_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -19,35 +19,30 @@ public class MentorChatRoomService {
     private final MentorChatRoomRepository mentorChatRoomRepository;
     private final MentorChatRoomDtoService mentorChatRoomDtoService;
 
-    @Transactional
-    public void createMentorChatRoom(String category, String subCategory, User mentee){
-        MentorChatRoom mentorChatRoom = new MentorChatRoom(category, subCategory, mentee);
-        mentorChatRoomRepository.save(mentorChatRoom);
-    }
-
-    public Page<MentorChatRoomResponse> getMentorChatRooms(User user, Pageable pageable){
-        Page<MentorChatRoom> mentorChatRoomPage = mentorChatRoomRepository.findByMenteeAndDeletedFalse(user, pageable);
-        return mentorChatRoomDtoService.toMentorChatRoomResponsePage(mentorChatRoomPage);
-    }
-
-    @Transactional
-    public void deleteMentorChatRoom(Long roomId, User user){
-        MentorChatRoom mentorChatRoom = mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
-                () -> new NoSuchElementException("No chat room found with id: " + roomId)
-        );
-        if (!mentorChatRoom.getMentee().equals(user)){
-            throw new IllegalArgumentException("The user is not a mentee of the chat room");
-        }
-        mentorChatRoom.setDeleted(true);
-    }
-
     public MentorChatRoom getMentorChatRoom(Long roomId, User user){
         MentorChatRoom mentorChatRoom =  mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
                 () -> new NoSuchElementException("No chat room found with id: " + roomId)
         );
-        if (!mentorChatRoom.getMentee().equals(user)){
+        if (!mentorChatRoom.getMentor().equals(user)){
             throw new IllegalArgumentException("The user is not a mentee of the chat room");
         }
         return mentorChatRoom;
+    }
+
+    @Transactional
+    public void joinMentorChatRoom(Long roomId, User mentor) {
+        MentorChatRoom mentorChatRoom = getMentorChatRoom(roomId, mentor);
+        mentorChatRoom.joinMentor(mentor);
+    }
+
+
+    public List<DetailMentorChatRoom> getDetailMentorChatRooms(){
+        List<MentorChatRoom> mentorChatRoomList = mentorChatRoomRepository.findByMentorNullAndDeletedFalse();
+        return mentorChatRoomDtoService.toDetailMentorChatRoomList(mentorChatRoomList);
+    }
+
+    public List<MentorChatRoomResponse> getMentorChatRooms(User mentor){
+        List<MentorChatRoom> mentorChatRoomList = mentorChatRoomRepository.findByMentorAndDeletedFalse(mentor);
+        return mentorChatRoomDtoService.toMentorChatRoomResponseList(mentorChatRoomList);
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
@@ -5,6 +5,7 @@ import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorCha
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.repository.MentorChatRoomRepository;
 import com.moci_3d_backend.domain.user.entity.User;
+import com.moci_3d_backend.global.exception.ServiceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,14 +25,17 @@ public class MentorChatRoomService {
                 () -> new NoSuchElementException("No chat room found with id: " + roomId)
         );
         if (!mentorChatRoom.getMentor().equals(user)){
-            throw new IllegalArgumentException("The user is not a mentee of the chat room");
+            throw new IllegalArgumentException("The user is not a mentor of the chat room");
         }
         return mentorChatRoom;
     }
 
     @Transactional
     public void joinMentorChatRoom(Long roomId, User mentor) {
-        MentorChatRoom mentorChatRoom = getMentorChatRoom(roomId, mentor);
+        MentorChatRoom mentorChatRoom = mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElse(null);
+        if (mentorChatRoom != null){
+            throw new ServiceException(400, "chat room already exists");
+        }
         mentorChatRoom.joinMentor(mentor);
     }
 

--- a/src/main/java/com/moci_3d_backend/global/webSocket/readme.md
+++ b/src/main/java/com/moci_3d_backend/global/webSocket/readme.md
@@ -1,0 +1,15 @@
+# WebSocket
+
+## WebSocketConfig
+
+여기에서 Websocket이 어느 경로로 접속해서
+어느경로로 메시지를 받을 것이고
+어느경로로 메시지를 전송할 것인지를 설정합니다.
+
+## security/JwtHandshakeInterceptor
+
+위에서 설정한 경로로 접속을 했을 경우의 동작을 설정합니다. 
+
+## security/StompJwtInterceptor
+
+위에서 설정한 메시지를 받았을 때의 동작을 설정합니다.


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>
- 멘티와 멘토의 controller를 분리했습니다.
- 멘토가 채팅방에 입장하는 기능, 멘토가 채팅방을 검색하는 기능을 구현했습니다.
- swagger 설명을 추가했습니다.
- global/websocket에 readme.md를 추가했습니다.

## 연결된 issue
<!--연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
<br>
close #59 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [✅] PR 제목 규칙 잘 지켰는가?
- [✅] 추가/수정사항을 설명하였는가?
- [✅] 이슈넘버를 적었는가?
- [✅] Approve 하기 전 확인 사항 체크했는가?
