### PR TITLE
[feat] : #83 채팅방 이전 내역 조회

### DIFF
--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
@@ -1,26 +1,23 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.controller;
 
-import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
-import com.moci_3d_backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
-import java.security.Principal;
-
 @Controller
 @RequiredArgsConstructor
-public class ApiV1MentorChatMessageController {
+public class ApiV1ChatMessageController {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final MentorChatMessageService mentorChatMessageService;
 
     @MessageMapping("send/{roomId}")
     public void sendMessage(
-            ChatMessage message,
+            ChatReceiveMessage message,
             @DestinationVariable(value = "roomId") Long roomId
 //            ,Principal principal
     ) {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
@@ -1,0 +1,30 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.controller;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatSendMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
+import com.moci_3d_backend.domain.user.entity.User;
+import com.moci_3d_backend.global.rsData.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/chat")
+@RequiredArgsConstructor
+public class ApiV1ChatMessageRestController {
+
+    private final MentorChatMessageService mentorChatMessageService;
+
+    @GetMapping("{roomId}")
+    public RsData<Void> getMessages(
+            @PathVariable(value = "roomId") Long roomId,
+            User user
+    ){
+        List<ChatSendMessage> chats = mentorChatMessageService.getMentorChatMessages(roomId, user);
+        return RsData.of(200, "success to get messages", null);
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/chat")
+@RequestMapping("/api/v1/chat/mentor/message")
 @RequiredArgsConstructor
 @Tag(name="채팅 메시지", description = "채팅 메시지 중 HTTP 관련 API")
 public class ApiV1ChatMessageRestController {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestController.java
@@ -4,6 +4,8 @@ import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatSendMess
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
 import com.moci_3d_backend.domain.user.entity.User;
 import com.moci_3d_backend.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,16 +17,18 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/chat")
 @RequiredArgsConstructor
+@Tag(name="채팅 메시지", description = "채팅 메시지 중 HTTP 관련 API")
 public class ApiV1ChatMessageRestController {
 
     private final MentorChatMessageService mentorChatMessageService;
 
     @GetMapping("{roomId}")
-    public RsData<Void> getMessages(
+    @Operation(summary = "[모두] 채팅방의 메시지 불러오기", description = "채팅방에 접속했을 때 호출하면 이전 메시지를 불러옵니다.")
+    public RsData<List<ChatSendMessage>> getMessages(
             @PathVariable(value = "roomId") Long roomId,
             User user
     ){
         List<ChatSendMessage> chats = mentorChatMessageService.getMentorChatMessages(roomId, user);
-        return RsData.of(200, "success to get messages", null);
+        return RsData.of(200, "success to get messages", chats);
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatReceiveMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatReceiveMessage.java
@@ -3,7 +3,7 @@ package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto;
 import lombok.Getter;
 
 @Getter
-public class ChatMessage {
+public class ChatReceiveMessage {
     private String sender;
     private String content;
     private Long attachmentId;

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
@@ -1,0 +1,16 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChatSendMessage {
+    private String sender;
+    private String content;
+    private Long attachmentId;
+
+    public ChatSendMessage(String sender, String content, Long attachmentId) {
+        this.sender = sender;
+        this.content = content;
+        this.attachmentId = attachmentId;
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/repository/MentorChatMessageRepository.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/repository/MentorChatMessageRepository.java
@@ -3,5 +3,9 @@ package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.repository;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MentorChatMessageRepository extends JpaRepository<MentorChatMessage, Long> {
+
+    public List<MentorChatMessage> findByRoomIdOrderByCreatedAtAsc(Long roomId);
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
@@ -1,0 +1,36 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service;
+
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatSendMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorChatMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import com.moci_3d_backend.domain.fileUpload.entity.FileUpload;
+import com.moci_3d_backend.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MentorChatMessageDtoService {
+
+    public ChatSendMessage toSendMessage(MentorChatMessage entity){
+        return new ChatSendMessage(
+                entity.getSender().getName(),
+                entity.getContent(),
+                entity.getAttachment().getId()
+        );
+    }
+
+    public MentorChatMessage toEntity(ChatReceiveMessage message, User sender, MentorChatRoom room, FileUpload fileUpload){
+        return new MentorChatMessage(
+                room,
+                sender,
+                message.getContent(),
+                fileUpload
+        );
+    }
+
+    public List<ChatSendMessage> toSendMessages(List<MentorChatMessage> entityList){
+        return entityList.stream().map(this::toSendMessage).toList();
+    }
+}

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
@@ -14,10 +14,11 @@ import java.util.List;
 public class MentorChatMessageDtoService {
 
     public ChatSendMessage toSendMessage(MentorChatMessage entity){
+        FileUpload attachment = entity.getAttachment();
         return new ChatSendMessage(
                 entity.getSender().getName(),
                 entity.getContent(),
-                entity.getAttachment().getId()
+                attachment != null ? attachment.getId() : null
         );
     }
 

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageService.java
@@ -1,9 +1,11 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service;
 
-import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatSendMessage;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorChatMessage;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.repository.MentorChatMessageRepository;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.entity.MentorChatRoom;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MenteeChatRoomService;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
 import com.moci_3d_backend.domain.fileUpload.entity.FileUpload;
 import com.moci_3d_backend.domain.fileUpload.repository.FileUploadRepository;
@@ -12,25 +14,42 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MentorChatMessageService {
 
     private final MentorChatMessageRepository mentorChatMessageRepository;
+    private final MenteeChatRoomService menteeChatRoomService;
     private final MentorChatRoomService mentorChatRoomService;
     private final FileUploadRepository fileUploadRepository;
+    private final MentorChatMessageDtoService mentorChatMessageDtoService;
+
+    private MentorChatRoom getChatRoomByUser(Long roomId, User user){
+        return switch (user.getRole()){
+            case MENTOR -> mentorChatRoomService.getMentorChatRoom(roomId, user);
+            case USER -> menteeChatRoomService.getMenteeChatRoom(roomId, user);
+            default -> null;
+        };
+    }
+
 
     @Transactional
-    public void saveMentorChatMessage(ChatMessage message, User sender, Long roomId){
+    public void saveMentorChatMessage(ChatReceiveMessage message, User sender, Long roomId){
         MentorChatRoom mentorChatRoom = mentorChatRoomService.getMentorChatRoom(roomId, sender);
         FileUpload fileUpload = fileUploadRepository.findById(message.getAttachmentId()).orElse(null);
-        MentorChatMessage mentorChatMessage = new MentorChatMessage(
-                mentorChatRoom,
-                sender,
-                message.getContent(),
-                fileUpload
-        );
+        MentorChatMessage mentorChatMessage = mentorChatMessageDtoService.toEntity(message, sender, mentorChatRoom, fileUpload);
         mentorChatMessageRepository.save(mentorChatMessage);
+    }
+
+    public List<ChatSendMessage> getMentorChatMessages(Long roomId, User user){
+        MentorChatRoom mentorChatRoom = getChatRoomByUser(roomId, user);
+        if (mentorChatRoom == null){
+            throw new IllegalArgumentException("The user is not a member of the chat room");
+        }
+        List<MentorChatMessage> chats = mentorChatMessageRepository.findByRoomIdOrderByCreatedAtAsc(roomId);
+        return mentorChatMessageDtoService.toSendMessages(chats);
     }
 
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/chat/mentor/mentee/chatroom")
+@RequestMapping("/api/v1/chat/mentor/mentee/room")
 @RequiredArgsConstructor
 @Tag(name="멘티의 채팅방", description = "멘티의 채팅방 관련 API")
 public class ApiV1MenteeChatRoomController {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/chat/mentee/room")
+@RequestMapping("/api/v1/mentee/chatroom")
 @RequiredArgsConstructor
 @Tag(name="멘티의 채팅방", description = "멘티의 채팅방 관련 API")
 public class ApiV1MenteeChatRoomController {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/mentee/chatroom")
+@RequestMapping("/api/v1/chat/mentor/mentee/chatroom")
 @RequiredArgsConstructor
 @Tag(name="멘티의 채팅방", description = "멘티의 채팅방 관련 API")
 public class ApiV1MenteeChatRoomController {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/mentor/chatroom")
+@RequestMapping("/api/v1/chat/mentor/mentor/chatroom")
 @RequiredArgsConstructor
 @Tag(name="멘토의 채팅방", description = "멘토의 채팅방 관련 API")
 public class ApiV1MentorChatRoomController {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/chat/mentor/mentor/chatroom")
+@RequestMapping("/api/v1/chat/mentor/mentor/room")
 @RequiredArgsConstructor
 @Tag(name="멘토의 채팅방", description = "멘토의 채팅방 관련 API")
 public class ApiV1MentorChatRoomController {

--- a/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestControllerTest.java
+++ b/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageRestControllerTest.java
@@ -1,0 +1,11 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ApiV1ChatMessageRestControllerTest {
+}

--- a/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomControllerTest.java
+++ b/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomControllerTest.java
@@ -1,0 +1,11 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ApiV1MenteeChatRoomControllerTest {
+}

--- a/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomControllerTest.java
+++ b/src/test/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomControllerTest.java
@@ -1,0 +1,11 @@
+package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ApiV1MentorChatRoomControllerTest {
+}


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>
채팅방에 들어가기전 이전 채팅 내용을 불러오기 위한 기능을 구현했습니다.
인증이 구현되면 테스트할 test 클래스를 만들어두기만 했습니다.
request url을 ai 채팅방과 비슷하게 변경했습니다.

## 연결된 issue
<!--연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
<br>
close #83 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [✅] PR 제목 규칙 잘 지켰는가?
- [✅] 추가/수정사항을 설명하였는가?
- [✅] 이슈넘버를 적었는가?
- [✅] Approve 하기 전 확인 사항 체크했는가?
- [✅] 민감정보가 노출되어 있는지 확인하였는가?