### PR TITLE
[fix] : swagger 설명 수정

### DIFF
--- a/src/main/java/com/moci_3d_backend/domain/archive/archive_request/controller/ArchiveRequestController.java
+++ b/src/main/java/com/moci_3d_backend/domain/archive/archive_request/controller/ArchiveRequestController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "자료 요청 게시판", description = "자료 요청 게시판 관련 API 입니다. **401의 경우 body에 credentials: \"include\" 필수 (쿠키 인증)**")
+@Tag(name = "자료 요청 게시판", description = "자료 요청 게시판 관련 API 입니다. **401의 경우 요청 시 credentials: \"include\" 필수 (쿠키 인증)**")
 public class ArchiveRequestController {
     private final ArchiveRequestService archiveRequestService;
     private final Rq rq;

--- a/src/main/java/com/moci_3d_backend/domain/archive/archive_request/controller/ArchiveRequestController.java
+++ b/src/main/java/com/moci_3d_backend/domain/archive/archive_request/controller/ArchiveRequestController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "자료 요청 게시판", description = "자료 요청 게시판 관련 API 입니다.")
+@Tag(name = "자료 요청 게시판", description = "자료 요청 게시판 관련 API 입니다. **401의 경우 body에 credentials: \"include\" 필수 (쿠키 인증)**")
 public class ArchiveRequestController {
     private final ArchiveRequestService archiveRequestService;
     private final Rq rq;

--- a/src/main/java/com/moci_3d_backend/domain/archive/public_archive/controller/PublicArchiveController.java
+++ b/src/main/java/com/moci_3d_backend/domain/archive/public_archive/controller/PublicArchiveController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "교육 자료실", description = "교육 자료실 관련 API 입니다.")
+@Tag(name = "교육 자료실", description = "교육 자료실 관련 API 입니다. **401의 경우 body에 credentials: \"include\" 필수 (쿠키 인증)**")
 public class PublicArchiveController {
 
     private final PublicArchiveService publicArchiveService;
@@ -96,7 +96,11 @@ public class PublicArchiveController {
     @PostMapping("/admin/archive/public")
     @PreAuthorize("hasRole('ADMIN')") // 관리자 권한 필요
     @Operation(summary = "[관리자] 교육 자료실 등록", description = "관리자만 교육자료실에 글을 등록할 수 있습니다.\n" +
-            "현재 플로우: 프론트에서 텍스트 및 파일**(선택사항 & 파일 첨부시 파일 업로드API먼저 호출 필요)** -> 양식에 맞게 본 API호출 -> DB저장")
+            "현재 플로우: 프론트에서 텍스트 및 파일**(선택사항 & 파일 첨부시 파일 업로드API먼저 호출 필요)** -> 양식에 맞게 본 API호출 -> DB저장\n" +
+            "⚠️ 주의사항:\n" +
+            "- **credentials: \"include\" 필수** (쿠키 인증)\n" +
+            "- title: 필수\n" +
+            "- category: 빈 문자열(\"\") 불가, null 또는 유효한 값만 가능")
     public RsData<PublicArchiveResponse> createPublicArchive(
             @Valid @RequestBody PublicArchiveCreateRequest request
     ) {

--- a/src/main/java/com/moci_3d_backend/domain/archive/public_archive/controller/PublicArchiveController.java
+++ b/src/main/java/com/moci_3d_backend/domain/archive/public_archive/controller/PublicArchiveController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
-@Tag(name = "교육 자료실", description = "교육 자료실 관련 API 입니다. **401의 경우 body에 credentials: \"include\" 필수 (쿠키 인증)**")
+@Tag(name = "교육 자료실", description = "교육 자료실 관련 API 입니다. **401의 경우 요청 시 credentials: \"include\" 필수 (쿠키 인증)**")
 public class PublicArchiveController {
 
     private final PublicArchiveService publicArchiveService;


### PR DESCRIPTION
## 📢 기능 설명

 기존 이슈 : [[fix] 교육 자료실 프론트 연동과정 문제 해결]
- 기존 프론트에서 api연결시 401발생하는 문제
=> 확인결과 프론트의 credential: include 필요

없을 경우:
<img width="260" height="88" alt="image" src="https://github.com/user-attachments/assets/c0d3fd64-1e04-4b17-95fa-43328e093acd" />

있을 경우:
<img width="269" height="118" alt="image" src="https://github.com/user-attachments/assets/25eeb2cd-0b8b-44a2-aac2-105449f163ed" />

<br>
<img width="412" height="210" alt="image" src="https://github.com/user-attachments/assets/99d7db50-c934-4b35-8b2f-b0aa20733dbf" />

결론 => Front팀이 알 수 있게 swagger 문서 수정

## 연결된 issue
<!--연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
<br>
close #141 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ] 결론 => swagger수정

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
- [ ] 민감정보가 노출되어 있는지 확인하였는가?