### PR TITLE
[fix] : #154 채팅방 FE 요구 반영

### DIFF
--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
@@ -33,7 +33,9 @@ public class ApiV1ChatMessageController {
         }
         Long roomId = Long.parseLong(roomIdStr);
         SecurityUser securityUser = (SecurityUser) principal;
-        User userRef = userService.getReferenceById(securityUser.getId());
-        mentorChatMessageService.sendMessage(roomId, message, Optional.of(userRef));
+        User user = new User();
+        user.setId(securityUser.getId());
+        user.setName(securityUser.getNickname());
+        mentorChatMessageService.sendMessage(roomId, message, Optional.of(user));
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/controller/ApiV1ChatMessageController.java
@@ -1,7 +1,6 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.controller;
 
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
-import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatSendMessage;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
 import com.moci_3d_backend.domain.user.entity.User;
 import com.moci_3d_backend.domain.user.service.UserService;
@@ -13,12 +12,12 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
+import java.util.Optional;
 
 @Controller
 @RequiredArgsConstructor
 public class ApiV1ChatMessageController {
 
-    private final SimpMessagingTemplate messagingTemplate;
     private final MentorChatMessageService mentorChatMessageService;
     private final UserService userService;
 
@@ -35,8 +34,6 @@ public class ApiV1ChatMessageController {
         Long roomId = Long.parseLong(roomIdStr);
         SecurityUser securityUser = (SecurityUser) principal;
         User userRef = userService.getReferenceById(securityUser.getId());
-        ChatSendMessage chatSendMessage = new ChatSendMessage(securityUser.getNickname(), message);
-        mentorChatMessageService.saveMentorChatMessage(message, userRef, roomId);
-        messagingTemplate.convertAndSend("/api/v1/chat/topic/%d".formatted(roomId), chatSendMessage);
+        mentorChatMessageService.sendMessage(roomId, message, Optional.of(userRef));
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatReceiveMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatReceiveMessage.java
@@ -1,9 +1,16 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class ChatReceiveMessage {
     private String content;
     private Long attachmentId;
+
+    public ChatReceiveMessage(String content, Long attachmentId) {
+        this.content = content;
+        this.attachmentId = attachmentId;
+    }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+
 @Getter
 public class ChatSendMessage {
     private Long id;
@@ -21,8 +22,10 @@ public class ChatSendMessage {
     }
 
     public ChatSendMessage(String sender, ChatReceiveMessage receiveMessage) {
+        this.id = -1L;
         this.sender = sender;
         this.content = receiveMessage.getContent();
         this.attachmentId = receiveMessage.getAttachmentId();
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/dto/ChatSendMessage.java
@@ -2,16 +2,22 @@ package com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto;
 
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class ChatSendMessage {
+    private Long id;
     private String sender;
     private String content;
     private Long attachmentId;
+    private LocalDateTime createdAt;
 
-    public ChatSendMessage(String sender, String content, Long attachmentId) {
+    public ChatSendMessage(Long id, String sender, String content, Long attachmentId, LocalDateTime createdAt) {
+        this.id = id;
         this.sender = sender;
         this.content = content;
         this.attachmentId = attachmentId;
+        this.createdAt = createdAt;
     }
 
     public ChatSendMessage(String sender, ChatReceiveMessage receiveMessage) {

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageDtoService.java
@@ -16,9 +16,11 @@ public class MentorChatMessageDtoService {
     public ChatSendMessage toSendMessage(MentorChatMessage entity){
         FileUpload attachment = entity.getAttachment();
         return new ChatSendMessage(
+                entity.getId(),
                 entity.getSender().getName(),
                 entity.getContent(),
-                attachment != null ? attachment.getId() : null
+                attachment != null ? attachment.getId() : null,
+                entity.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatMessage/service/MentorChatMessageService.java
@@ -41,6 +41,9 @@ public class MentorChatMessageService {
     @Transactional
     public ChatSendMessage saveMentorChatMessage(ChatReceiveMessage message, User sender, Long roomId){
         MentorChatRoom mentorChatRoom = mentorChatRoomService.getChatRoomById(roomId).orElseThrow(() -> new IllegalArgumentException("No chat room found"));
+        if (mentorChatRoom.isDeleted() || mentorChatRoom.isSolved()){
+            throw new IllegalArgumentException("The chat room is read-only");
+        }
         FileUpload fileUpload = fileUploadRepository.findById(message.getAttachmentId()).orElse(null);
         MentorChatMessage mentorChatMessage = mentorChatMessageDtoService.toEntity(message, sender, mentorChatRoom, fileUpload);
         mentorChatMessage = mentorChatMessageRepository.save(mentorChatMessage);
@@ -68,5 +71,4 @@ public class MentorChatMessageService {
         }
         messagingTemplate.convertAndSend("/api/v1/chat/topic/%d".formatted(roomId), chatSendMessage);
     }
-
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MenteeChatRoomController.java
@@ -1,5 +1,7 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
 
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.CreateMentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MenteeChatRoomService;
@@ -9,11 +11,10 @@ import com.moci_3d_backend.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/chat/mentor/mentee/room")
@@ -22,6 +23,7 @@ import java.util.List;
 public class ApiV1MenteeChatRoomController {
     private final MenteeChatRoomService menteeChatRoomService;
     private final Rq rq;
+    private final MentorChatMessageService mentorChatMessageService;
 
     @PostMapping()
     @Operation(summary = "[멘티] 채팅방 생성", description = "멘티가 채팅방을 생성합니다.")
@@ -48,6 +50,8 @@ public class ApiV1MenteeChatRoomController {
     ){
         User user = rq.getActor();
         menteeChatRoomService.deleteMenteeChatRoom(roomId, user);
+        ChatReceiveMessage chatReceiveMessage = new ChatReceiveMessage("멘티님이 채팅방을 나가셨습니다.", 0L);
+        mentorChatMessageService.sendMessage(roomId, chatReceiveMessage, Optional.empty());
         return RsData.of(200, "success to delete chat room");
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/controller/ApiV1MentorChatRoomController.java
@@ -1,5 +1,7 @@
 package com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.controller;
 
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.dto.ChatReceiveMessage;
+import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.service.MentorChatMessageService;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.MentorChatRoomResponse;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.DetailMentorChatRoom;
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.service.MentorChatRoomService;
@@ -13,6 +15,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/v1/chat/mentor/mentor/room")
@@ -21,6 +24,7 @@ import java.util.List;
 public class ApiV1MentorChatRoomController {
     private final MentorChatRoomService mentorChatRoomService;
     private final Rq rq;
+    private final MentorChatMessageService mentorChatMessageService;
 
     @PutMapping("/join/{roomId}")
     @PreAuthorize("hasRole('MENTOR')")
@@ -56,5 +60,17 @@ public class ApiV1MentorChatRoomController {
     public RsData<List<DetailMentorChatRoom>> getAllChatRooms(){
         List<DetailMentorChatRoom> chatRooms = mentorChatRoomService.getAllMentorChatRooms();
         return RsData.of(200, "success to load chat rooms", chatRooms);
+    }
+
+    @PutMapping("/exit/{roomId}")
+    @PreAuthorize("hasRole('MENTOR')")
+    @Operation(summary = "[멘토] 채팅방이 해결되었음 ")
+    public RsData<Void> closeChatRoom(
+            @PathVariable(value = "roomId") Long roomId
+    ){
+        ChatReceiveMessage chatreceiveMessage = new ChatReceiveMessage("멘토님이 채팅방을 나가셨습니다.", 0L);
+        mentorChatMessageService.sendMessage(roomId, chatreceiveMessage, Optional.empty());
+        mentorChatRoomService.setSolved(roomId);
+        return RsData.of(200, "success to close chat room");
     }
 }

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/dto/MentorChatRoomResponse.java
@@ -9,19 +9,22 @@ import java.time.LocalDateTime;
 @Getter
 public class MentorChatRoomResponse {
     private Long id;
+    private String category;
     private String question;
     private Long unread_count;
     private LocalDateTime createdAt;
 
     public MentorChatRoomResponse(MentorChatRoom entity){
         this.id = entity.getId();
+        this.category = entity.getCategory();
         this.question = entity.getQuestion();
         this.unread_count = 0L;
         this.createdAt = entity.getCreatedAt();
     }
     @QueryProjection
-    public MentorChatRoomResponse(Long id, String question, Long unread_count, LocalDateTime createdAt){
+    public MentorChatRoomResponse(Long id, String category, String question, Long unread_count, LocalDateTime createdAt){
         this.id = id;
+        this.category = category;
         this.question = question;
         this.unread_count = unread_count;
         this.createdAt = createdAt;

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/entity/MentorChatRoom.java
@@ -4,12 +4,10 @@ import com.moci_3d_backend.domain.chat.mentor.mentorChatMessage.entity.MentorCha
 import com.moci_3d_backend.domain.chat.mentor.mentorChatRoom.dto.CreateMentorChatRoom;
 import com.moci_3d_backend.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -59,6 +57,9 @@ public class MentorChatRoom {
     @Setter
     private boolean deleted;
 
+    @Setter
+    private boolean solved;
+
     @OneToMany(mappedBy = "room")
     List<MentorChatMessage> mentorChatMessageList;
 
@@ -69,6 +70,7 @@ public class MentorChatRoom {
         this.status = true;
         this.menteeLastAt = LocalDateTime.now();
         this.deleted = false;
+        this.solved = false;
     }
 
     public MentorChatRoom(CreateMentorChatRoom createMentorChatRoom, User mentee){
@@ -78,6 +80,7 @@ public class MentorChatRoom {
         this.mentee = mentee;
         this.menteeLastAt = LocalDateTime.now();
         this.deleted = false;
+        this.solved = false;
     }
 
     public void joinMentor(User mentor){

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepositoryImpl.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/repository/MentorChatRoomRepositoryImpl.java
@@ -30,6 +30,7 @@ public class MentorChatRoomRepositoryImpl implements MentorChatRoomRepositoryCus
         if (user != null){
             if (isMentor){
                 builder.and(chatRoom.mentor.eq(user));
+                builder.and(chatRoom.solved.isFalse());
                 joinBuilder.and(message.createdAt.after(chatRoom.mentorLastAt));
             }else{
                 builder.and(chatRoom.mentee.eq(user));
@@ -43,6 +44,7 @@ public class MentorChatRoomRepositoryImpl implements MentorChatRoomRepositoryCus
         return jpaQueryFactory
                 .select(new QMentorChatRoomResponse(
                         chatRoom.id,
+                        chatRoom.category,
                         chatRoom.question,
                         message.count().as("unread_count"),
                         chatRoom.createdAt

--- a/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
+++ b/src/main/java/com/moci_3d_backend/domain/chat/mentor/mentorChatRoom/service/MentorChatRoomService.java
@@ -60,6 +60,14 @@ public class MentorChatRoomService {
         return mentorChatRoomRepository.findByIdAndDeletedFalse(roomId);
     }
 
+    @Transactional
+    public void setSolved(Long roomId){
+        MentorChatRoom mentorChatRoom = mentorChatRoomRepository.findByIdAndDeletedFalse(roomId).orElseThrow(
+                () -> new NoSuchElementException("No chat room found with id: " + roomId)
+        );
+        mentorChatRoom.setSolved(true);
+    }
+
     public Long getChatRoomCount(){
         return mentorChatRoomRepository.count();
     }


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>
<img width="763" height="820" alt="image" src="https://github.com/user-attachments/assets/c1cb6293-ce59-419a-bff2-cee9b4fa66f9" />
<img width="1444" height="65" alt="image" src="https://github.com/user-attachments/assets/1b1a1153-736d-4df8-8952-f5ed3bf544d1" />
swagger랑 제가 제작한 FE 테스트 코드를 사용해서 간략하게 테스트를 해봤습니다.

AI 채팅방으로 넘어가기 위해 채팅방 생성시 category를 전달하게 수정했고
메시지 조회할 때 id값, createdAt 값을 추가했습니다.

그리고 멘토가 채팅방을 나갈 때 채팅방에 solved를 true로 변경하고 내 멘토 채팅 방을 조회할 때는 안뜨게 변경했습니다.
그리고 채팅방에서는 System이 "멘토님이 채팅방을 나가셨습니다"를 채팅방에 전송해서 채팅이 종료되었음을 알리고
채팅 작성하는 것을 막아둡니다.


## 연결된 issue
<!--연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
<br>
close #154 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [✅] PR 제목 규칙 잘 지켰는가?
- [✅] 추가/수정사항을 설명하였는가?
- [✅] 이슈넘버를 적었는가?
- [✅] Approve 하기 전 확인 사항 체크했는가?
- [✅] 민감정보가 노출되어 있는지 확인하였는가?